### PR TITLE
hotfix/report-security: all report path access allowed

### DIFF
--- a/src/main/java/seasonton/youthPolicy/global/config/SecurityConfig.java
+++ b/src/main/java/seasonton/youthPolicy/global/config/SecurityConfig.java
@@ -43,12 +43,10 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",
                                 "/ping",
-                                "/user/signup",
-                                "/user/doLogin",
-                                "/user/nameCheck",
-                                "/user/emailCheck",
                                 "/youth/policies/**",
-                                "/posts/**"
+                                "/user/**",
+                                "/posts/**",
+                                "/reports/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 📌 report 관련 모든 API 주소에 어디서든 접근할 수 있도록 제한 삭제
